### PR TITLE
Fixed bug when trying to delete member from list

### DIFF
--- a/src/main/java/model/list/MailChimpList.java
+++ b/src/main/java/model/list/MailChimpList.java
@@ -201,7 +201,7 @@ public class MailChimpList extends MailchimpObject {
 	 * @throws Exception
 	 */
 	public void deleteMemberFromList(String memberID) throws Exception{
-		getConnection().do_Delete(new URL(connection.getListendpoint()+getId()+"/members/"+memberID),connection.getApikey());
+		getConnection().do_Delete(new URL(connection.getListendpoint()+"/"+getId()+"/members/"+memberID),connection.getApikey());
 		this.membercount--;
 	}
 	


### PR DESCRIPTION
Slash was forgotten when trying to call MailChimp endpoint when trying to remove a member